### PR TITLE
Add resource server

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -17,6 +17,7 @@ class AppKernel extends Kernel
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new AppBundle\AppBundle(),
             new FOS\OAuthServerBundle\FOSOAuthServerBundle(),
+            new Nelmio\CorsBundle\NelmioCorsBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -69,3 +69,11 @@ fos_oauth_server:
         user_provider: AppBundle\Security\UserProvider
         options:
             supported_scopes: read:email read:profile
+
+# CORS configuration
+nelmio_cors:
+    paths:
+        '^/api/':
+            allow_origin: ['*']
+            allow_headers: ['*']
+            allow_methods: ['POST', 'PUT', 'GET', 'DELETE']

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -29,6 +29,14 @@ security:
                 success_handler: AppBundle\Security\LogoutHandler
             logout_on_user_change: true
 
+        api:
+            pattern: ^/api/
+            fos_oauth: true
+            stateless: true
+
         main:
             anonymous: ~
             logout_on_user_change: true
+
+    access_control:
+        - { path: ^/api/, roles: [ IS_AUTHENTICATED_FULLY ] }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "doctrine/orm": "^2.5",
         "friendsofsymfony/oauth-server-bundle": "^1.5",
         "incenteev/composer-parameter-handler": "^2.0",
+        "nelmio/cors-bundle": "^1.5",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "symfony/monolog-bundle": "^3.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac00dba6ff37ac744fab53649fcbf632",
+    "content-hash": "33b943140ede1b849070b45e55cff37f",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1192,6 +1192,64 @@
                 "psr-3"
             ],
             "time": "2017-06-19T01:22:40+00:00"
+        },
+        {
+            "name": "nelmio/cors-bundle",
+            "version": "1.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nelmio/NelmioCorsBundle.git",
+                "reference": "548dc8ebd3984acd2f6d8787ab1dac2e9aa14254"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nelmio/NelmioCorsBundle/zipball/548dc8ebd3984acd2f6d8787ab1dac2e9aa14254",
+                "reference": "548dc8ebd3984acd2f6d8787ab1dac2e9aa14254",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "matthiasnoback/symfony-dependency-injection-test": "^1.0 || ^2.0",
+                "mockery/mockery": "^0.9 || ^1.0",
+                "symfony/phpunit-bridge": "^2.7 || ^3.0 || ^4.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nelmio\\CorsBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nelmio",
+                    "homepage": "http://nelm.io"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://github.com/nelmio/NelmioCorsBundle/contributors"
+                }
+            ],
+            "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Symfony2 application",
+            "keywords": [
+                "api",
+                "cors",
+                "crossdomain"
+            ],
+            "time": "2017-12-11T18:41:54+00:00"
         },
         {
             "name": "paragonie/random_compat",

--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use AppBundle\Entity\Client;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class ApiController extends Controller
+{
+    /**
+     * @Route("/api/me", name="api_me")
+     */
+    public function meAction(Request $request)
+    {
+        $user = $this->getUser();
+
+        return new JsonResponse([
+            'username' => $user->getUsername(),
+        ]);
+    }
+}


### PR DESCRIPTION
Until now the auth server was only issuing authorizations to access resources. For the sake of the demo, we also need to expose some resources (like the user profile, product catalog, etc).

In theory, auth server (issuing authorizations) and resource server (exposing resources) can be separate. However, in practice, both are often merged into the same app.

This PR adds an API endpoint `/api/me` that will return a JSON view of the profile of authenticated user (actually, only the username for now).