### PR TITLE
Better catalog endpoint

### DIFF
--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -28,6 +28,7 @@ class ApiController extends Controller
     public function catalogAction(Request $request)
     {
         return new JsonResponse([
+            'username' => $this->getUser()->getUsername(),
             'products' => [
                 [
                     'type' => 'Tomate',

--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -33,17 +33,17 @@ class ApiController extends Controller
                 [
                     'type' => 'Tomate',
                     'nature' => 'Tomate coeur de boeuf',
-                    'quantity' => 20,
+                    'quantity' => rand(10, 30),
                 ],
                 [
                     'type' => 'Tomate',
                     'nature' => 'Tomate marmande',
-                    'quantity' => 10,
+                    'quantity' => rand(5, 15),
                 ],
                 [
                     'type' => 'Miel',
                     'nature' => 'Miel de thym',
-                    'quantity' => 10,
+                    'quantity' => rand(5, 15),
                 ]
             ],
         ]);


### PR DESCRIPTION
Endpoint `/api/catalog` now returns the username and random quantity, so it's easier to distinguish data from two different, fake accounts:

```diff
{
    "products": [
        {
            "nature": "Tomate coeur de boeuf",
-           "quantity": 20,
+           "quantity": 26,
            "type": "Tomate"
        },
        {
            "nature": "Tomate marmande",
-           "quantity": 10,
+           "quantity": 9,
            "type": "Tomate"
        },
        {
            "nature": "Miel de thym",
-           "quantity": 10,
+           "quantity": 15,
            "type": "Miel"
        }
    ],
+   "username": "nicolas"
}
```