### PR TITLE
Update icu4c download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM php:7.2.0-fpm
 COPY docker/php/config/php.ini /usr/local/etc/php/
 
 # see https://github.com/docker-library/php/issues/307
-RUN curl -sS -o /tmp/icu.tar.gz -L http://download.icu-project.org/files/icu4c/60.1/icu4c-60_1-src.tgz && \
+RUN curl -sS -o /tmp/icu.tar.gz -L https://github.com/unicode-org/icu/releases/download/release-60-1/icu4c-60_1-src.tgz && \
     tar -zxf /tmp/icu.tar.gz -C /tmp && \
     cd /tmp/icu/source && \
     ./configure --prefix=/usr/local && \


### PR DESCRIPTION
The old one was broken and Docker was failing with:

```
Step 3/12 : RUN curl -sS -o /tmp/icu.tar.gz -L http://download.icu-project.org/files/icu4c/60.1/icu4c-60_1-src.tgz &&     tar -zxf /tmp/icu.tar.gz -C /tmp &&     cd /tmp/icu/source &&     ./configure --prefix=/usr/local &&     make &&     make install
 ---> Running in 67363b684444
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
ERROR: Service 'oauth_lrqdo' failed to build: The command '/bin/sh -c curl -sS -o /tmp/icu.tar.gz -L http://download.icu-project.org/files/icu4c/60.1/icu4c-60_1-src.tgz &&     tar -zxf /tmp/icu.tar.gz -C /tmp &&     cd /tmp/icu/source &&     ./configure --prefix=/usr/local &&     make &&     make install' returned a non-zero code: 60
```

There are newer releases including newer patch releases for this version we could update to. But it's the first time I'm trying this out and I didn't want to change too much.